### PR TITLE
Saving gen info for MC

### DIFF
--- a/analysis/ddp.py
+++ b/analysis/ddp.py
@@ -1,6 +1,53 @@
 import ROOT
 from common.pyhelpers import load_meta_data
 ROOT.gInterpreter.Declare('#include "analysis/ddp_vertex.h"')
+
+opts = ROOT.RDF.RSnapshotOptions()
+opts.fMode = "UPDATE"
+opts.fOverwriteIfExists = True
+
+# Common Object ID:
+def muonAna(dataframe):
+
+    # Common Muon ID definitions (No isolation)
+    muons = dataframe.Define("loose_muon", "Muon_looseId==1&&abs(Muon_eta)<2.5&&Muon_dxy<0.2&&abs(Muon_dz)<0.5&&Muon_pt>10")
+    muons = muons.Define("tight_muon", "loose_muon&&Muon_tightId")
+
+    return muons
+
+def electronAna(dataframe):
+
+    # Common Electron ID definitions
+    electrons = dataframe.Define("loose_electrons", "Electron_pt>15&&abs(Electron_eta)<2.5&&(abs(Electron_eta)>1.57||abs(Electron_eta)<1.44)&&Electron_dxy<0.2&&abs(Electron_dz)<0.2&&Electron_lostHits<2&&Electron_convVeto&&Electron_cutBased>0")
+    return electrons
+
+# Must run muon + electron analyzer first to do overlap with loose leptons
+def photonAna(dataframe):
+
+    # Photon Preselection criteria
+    photons = dataframe.Define("Photon_preselection", "Photon_pt>20&&!Photon_pixelSeed&&abs(Photon_eta)<2.5&&(abs(Photon_eta)>1.57||abs(Photon_eta)<1.44)")
+
+    photons = photons.Define("Photon_muOverlap", "overlapClean(Photon_phi, Photon_eta, Muon_phi, Muon_eta, loose_muon)")
+    photons = photons.Define("Photon_eleOverlap", "overlapClean(Photon_phi, Photon_eta, Electron_phi, Electron_eta, loose_electrons)")
+    photons = photons.Define("Photon_overlap", "Photon_muOverlap||Photon_eleOverlap")
+
+    # Common Photon ID definitions (No isolation)
+    photons = photons.Define("Photon_IDNoIso","((Photon_isScEtaEB&&Photon_hoe<0.04596&&Photon_sieie<0.0106)||(Photon_isScEtaEE&&Photon_hoe<0.0590&&Photon_sieie<0.0272))").Filter('Sum(Photon_IDNoIso)>0','At least one ID No Iso Photon')
+
+    return photons    
+
+def makeZ(dataframe, lepton):
+    # pT, eta, phi, mass, deltaR, deltaPhi
+    Zs = dataframe.Define("Z_idx", "best_z({L}_pt[loose_{l}], {L}_eta[loose_{l}], {L}_phi[loose_{l}], {L}_mass[loose_{l}], {L}_charge[loose_{l}])".format(L=lepton, l=lepton.lower()))
+    Zs = Zs.Define("bestZ_info", "best_Z_info({l}_pt, {l}_eta, {l}_phi, {l}_mass, Z_idx)".format(l=lepton))
+    Zs = Zs.Define("Z_pt", "bestZ_info[0]")
+    Zs = Zs.Define("Z_eta", "bestZ_info[1]")
+    Zs = Zs.Define("Z_phi", "bestZ_info[2]")
+    Zs = Zs.Define("Z_mass", "bestZ_info[3]")
+    Zs = Zs.Define("Z_deltaR", "bestZ_info[4]")
+    Zs = Zs.Define("Z_deltaPhi", "bestZ_info[5]")
+    return Zs
+
 def zeeH(data,phi_mass=[5,10,20,30]):
     actions=[]
 
@@ -40,7 +87,7 @@ def ggH(data,phi_mass=[5,10,20,30]):
     #Declare dataframe and load all meta data 
     dataframe =load_meta_data(data)
     #pass HLT
-    ggH = dataframe.Filter('HLT_passed','passed HLT')
+    ggH = dataframe['Events'].Filter('HLT_passed','passed HLT')
     
     #your code here 
     ggH=ggH.Filter('nPhoton>2','At least three photons')
@@ -153,6 +200,11 @@ def ggH(data,phi_mass=[5,10,20,30]):
     actions.append(ggH3g.Snapshot('ggH3g','ggH3g.root',"best_3g.*|sample_.*|.*LHE.*|Pileup.*|^PV.*|run|event|luminosity|Block|genWeight"))
     actions.append(ggH3g_antiID.Snapshot('ggH3g_antiID','ggH3g_antiID.root',"best_3g.*|sample_.*|.*LHE.*|Pileup.*|^PV.*|run|event|luminosity|Block|genWeight"))
 
+    for tree in ['Runs']:
+        actions.append(dataframe[tree].Snapshot(tree, "ggH4g.root", "", opts))
+        actions.append(dataframe[tree].Snapshot(tree, "ggH3g.root", "", opts))
+        actions.append(dataframe[tree].Snapshot(tree, "ggH3g_antiID.root", "", opts))
+
     #r=ggH.Report()
     #r.Print()
 
@@ -169,36 +221,37 @@ def zmumuH(data,phi_mass=[5,10,20,30]):
     ####################
 
     #pass HLT
-    zmm = dataframe.Filter('HLT_passed','passed HLT')
-    #Apply Muon ID (no ISO)
-    zmm = zmm.Define("good_muons",'Muon_looseId==1').Filter("Sum(good_muons)>1","At least two good muons")
+    zmm = dataframe['Events'].Filter('HLT_passed','passed HLT')
+    #Apply Lepton ID (no ISO)
+    zmm = muonAna(zmm)
+    zmm = electronAna(zmm)
     #Look for + and - muons
-    zmm = zmm.Filter("Sum(Muon_charge[good_muons]==1)>0 && Sum(Muon_charge[good_muons]==-1)>0","At least one opposite sign muon pair")
+    zmm = zmm.Filter("Sum(Muon_charge[loose_muon]==1)>0 && Sum(Muon_charge[loose_muon]==-1)>0","At least one opposite sign muon pair")
     #create the best Zmumu candidate 
-    zmm = zmm.Define("Zmumu_idx", "best_z(Muon_pt[good_muons], Muon_eta[good_muons], Muon_phi[good_muons], Muon_mass[good_muons], Muon_charge[good_muons])")
+    zmm = makeZ(zmm, "Muon")  
     #Apply Thresholds to the muon pts
-    zmm = zmm.Filter("(Muon_pt[Zmumu_idx[0]]>8&&Muon_pt[Zmumu_idx[1]]>8)&&(Muon_pt[Zmumu_idx[0]]>27||Muon_pt[Zmumu_idx[1]]>27)","Muons above threshold")
+    zmm = zmm.Filter("(tight_muon[Z_idx[0]]||tight_muon[Z_idx[1]])&&(Muon_pt[Z_idx[0]]>25||Muon_pt[Z_idx[1]]>25)")
     #require just a super cluster
     zmm = zmm.Filter("nPhoton>0","At least one super cluster")
     
     #Apply photon ID (no ISO)
-    zmm =zmm.Define("Photon_IDNoIso","((Photon_isScEtaEB&&Photon_hoe<0.04596&&Photon_sieie<0.0106)||(Photon_isScEtaEE&&Photon_hoe<0.0590&&Photon_sieie<0.0272))&&(Photon_electronVeto==1)&&(Photon_eta>-2.5&&Photon_eta<2.5)").Filter('Sum(Photon_IDNoIso)>0','At least one ID No Iso Photon')
-
-#    zmm =zmm.Define("Photon_IDNoIso","((Photon_isScEtaEB&&Photon_hoe<0.2&&Photon_sieie<0.05)||(Photon_isScEtaEE&&Photon_hoe<0.2&&Photon_sieie<0.05))&&(Photon_electronVeto==1)&&(Photon_eta>-2.5&&Photon_eta<2.5)").Filter('Sum(Photon_IDNoIso)>0','At least one ID No Iso Photon')
+    zmm = photonAna(zmm)
 
     #Correct Photon Isolation for both muons and photons
-    zmm=zmm.Define("Photon_corrIso","correct_gammaIso_for_muons_and_photons(Zmumu_idx,Muon_pt,Muon_eta,Muon_phi,Photon_pt,Photon_eta,Photon_phi,Photon_pfRelIso03_all,Photon_IDNoIso)")
+    zmm=zmm.Define("Photon_corrIso","correct_gammaIso_for_muons_and_photons(Z_idx,Muon_pt,Muon_eta,Muon_phi,Photon_pt,Photon_eta,Photon_phi,Photon_pfRelIso03_all,Photon_IDNoIso)")
     #Define ID and isolation
     zmm=zmm.Define("Photon_ID","Photon_IDNoIso==1 &&Photon_corrIso<0.1")
     #At least one Photon
     zmm=zmm.Filter('Sum(Photon_ID==1)>0','At least one ID photon')
     #FSR recovery
-    zmm=zmm.Define("fsr","fsr_recovery(Zmumu_idx,Muon_pt[good_muons], Muon_eta[good_muons], Muon_phi[good_muons], Muon_mass[good_muons],Photon_pt,Photon_eta,Photon_phi,Photon_ID)");
+    zmm=zmm.Define("fsr","fsr_recovery(Z_idx,Muon_pt[loose_muon], Muon_eta[loose_muon], Muon_phi[loose_muon], Muon_mass[loose_muon],Photon_pt,Photon_eta,Photon_phi,Photon_ID)");
     #Correct Muon isolation for photons
-    zmm=zmm.Define("corr_muon_iso","correct_muoniso_for_photons(Muon_pt, Muon_eta,Muon_phi,Muon_pfRelIso03_all,Photon_pt,Photon_eta,Photon_phi,fsr)");
-    zmm=zmm.Filter("(corr_muon_iso[Zmumu_idx[0]]<0.15) &&(corr_muon_iso[Zmumu_idx[1]]<0.15)","Muon Isolation with FSR recovery")
+    zmm=zmm.Define("corr_muon_iso","correct_muoniso_for_photons(Muon_pt, Muon_eta,Muon_phi,Muon_pfRelIso04_all,Photon_pt,Photon_eta,Photon_phi,fsr)");
+    zmm = zmm.Define("Muon_pfIsoId_corr", "1*corr_muon_iso<0.4+1*corr_muon_iso<.25+1*corr_muon_iso<.20+1*corr_muon_iso<.15+1*corr_muon_iso<.10+1*corr_muon_iso<.05")
+    zmm = zmm.Define("Muon_isLoose_corr", "loose_muon&&Muon_pfIsoId_corr>1")
+    zmm = zmm.Define("Muon_isTight_corr", "tight_muon&&Muon_pfIsoId_corr>3")
     #Now cut on the ll+gamma mass around the Z 
-    zmm=zmm.Define("llgamma_mass","calculate_llgamma_mass(Zmumu_idx,Muon_pt[good_muons], Muon_eta[good_muons], Muon_phi[good_muons], Muon_mass[good_muons],Photon_pt,Photon_eta,Photon_phi, fsr)").Filter('llgamma_mass>75&&llgamma_mass<115','Z+gamma mass near the Z')
+    zmm=zmm.Define("llgamma_mass","calculate_llgamma_mass(Z_idx,Muon_pt[loose_muon], Muon_eta[loose_muon], Muon_phi[loose_muon], Muon_mass[loose_muon],Photon_pt,Photon_eta,Photon_phi, fsr)").Filter('llgamma_mass>75&&llgamma_mass<115','Z+gamma mass near the Z')
     #Define good photons
     zmm=zmm.Define('good_photons','fsr==0&&Photon_ID==1')
 
@@ -218,7 +271,9 @@ def zmumuH(data,phi_mass=[5,10,20,30]):
         zmm2g=zmm2g.Define('best_2g_dxy_m{}'.format(mass),'raw_best_2g_m{}[6]'.format(mass))
         zmm2g=zmm2g.Define('best_2g_valid_m{}'.format(mass),'raw_best_2g_m{}[7]'.format(mass))
         zmm2g=zmm2g.Define('best_2g_raw_mass_m{}'.format(mass),'raw_best_2g_m{}[8]'.format(mass))
-
+        zmm2g=zmm2g.Define('best_2g_idx1_m{}'.format(mass),'raw_best_2g_m{}[9]'.format(mass))
+        zmm2g=zmm2g.Define('best_2g_idx2_m{}'.format(mass),'raw_best_2g_m{}[10]'.format(mass))
+        zmm2g=zmm2g.Define('best_2g_sumID_m{}'.format(mass), 'Photon_ID[best_2g_idx1_m{m}]+Photon_ID[best_2g_idx2_m{m}]'.format(m=mass))
     
     ##### 3 gamma analysis ######
     #Targets events where one two photons are merged
@@ -272,9 +327,13 @@ def zmumuH(data,phi_mass=[5,10,20,30]):
         zmm4g=zmm4g.Define('best_4g_corr_mass_m{}'.format(mass),'raw_best_4g_m{}[19]'.format(mass))
      
         
-    actions.append(zmm2g.Snapshot('zmm2g','zmm2g.root',"best_2g.*|sample_.*"))
-    actions.append(zmm3g.Snapshot('zmm3g','zmm3g.root',"best_3g.*|sample_.*"))
-    actions.append(zmm4g.Snapshot('zmm4g','zmm4g.root',"best_4g.*|sample_.*"))
+    actions.append(zmm2g.Snapshot('zmm2g','zmm2g.root',"best_2g.*|sample_.*|^Photon_.*|^Muon_.*|^Z_.*|Weight.*|^Gen.*|^weight.*"))
+    actions.append(zmm3g.Snapshot('zmm3g','zmm3g.root',"best_3g.*|sample_.*|^Photon_.*|^Muon_.*|^Z_.*|Weight.*|^Gen.*|^weight.*"))
+    actions.append(zmm4g.Snapshot('zmm4g','zmm4g.root',"best_4g.*|sample_.*|^Photon_.*|^Muon_.*|^Z_.*|Weight.*|^Gen.*|^weight.*"))
+    for tree in ['Runs']:
+        actions.append(dataframe[tree].Snapshot(tree, 'zmm2g.root', "", opts))
+        actions.append(dataframe[tree].Snapshot(tree, 'zmm3g.root', "", opts))
+        actions.append(dataframe[tree].Snapshot(tree, 'zmm4g.root', "", opts))
 #    r=zmm2g.Report()
 #    r.Print()
     return actions

--- a/analysis/ddp_vertex.h
+++ b/analysis/ddp_vertex.h
@@ -425,13 +425,13 @@ RVecF best_2gamma(RVecF pt,RVecF eta, RVecF phi,RVec<bool> EB, RVec<bool> EE,flo
     
 
     RVecF result;
-    result.reserve(9);
+    result.reserve(11);
     VertexCalculator *calc = new VertexCalculator();
     //four vector
-    ROOT::Math::PtEtaPhiMVector p0(pt[0],eta[0],phi[0],0.0);
-    ROOT::Math::PtEtaPhiMVector p1(pt[1],eta[1],phi[1],0.0);
+    ROOT::Math::PtEtaPhiMVector p0(pt[i1],eta[i1],phi[i1],0.0);
+    ROOT::Math::PtEtaPhiMVector p1(pt[i2],eta[i2],phi[i2],0.0);
     float raw_m = (p0+p1).M();
-    std::vector<float> kin_fit= calc->getVertexInfo(pt[0],eta[0],phi[0],EE[0],EB[0],pt[1],eta[1],phi[1],EE[1],EB[1],mass); 
+    std::vector<float> kin_fit= calc->getVertexInfo(pt[i1],eta[i1],phi[i1],EE[i1],EB[i1],pt[i2],eta[i2],phi[i2],EE[i2],EB[i2],mass); 
     delete calc;
     result.emplace_back(kin_fit[0]);
     result.emplace_back(kin_fit[1]);
@@ -442,6 +442,8 @@ RVecF best_2gamma(RVecF pt,RVecF eta, RVecF phi,RVec<bool> EB, RVec<bool> EE,flo
     result.emplace_back(kin_fit[6]);
     result.emplace_back(kin_fit[7]);
     result.emplace_back(raw_m);
+    result.emplace_back(i1);
+    result.emplace_back(i2);
     all_combos.emplace_back(result);
   }
   auto sortedIndices = ROOT::VecOps::Argsort(all_combos,compare_pair);

--- a/common/chelpers.h
+++ b/common/chelpers.h
@@ -51,6 +51,42 @@ RVec<size_t> best_z(RVecF pt, RVecF eta, RVecF phi, RVecF mass, RVecI charge)
   return result;
 }
 
+
+RVec<bool> overlapClean(RVecF gphi, RVecF geta, RVecF lphi, RVecF leta, RVecF lID){
+  RVec<bool> out;
+  out.reserve(gphi.size());
+  for (size_t i = 0; i < gphi.size(); i++){
+    bool overlap = false;
+    for (size_t j = 0; j < lphi.size(); j++){
+      if (lID[j]){
+	if (pow(DeltaPhi(gphi[i], lphi[j]),2)/0.5 + pow(abs(geta[i] - leta[j]), 2)/0.4 < 1){
+	  overlap = true;
+	  break;
+	}
+      }
+    }
+    out.emplace_back(overlap);
+  }
+  return out;
+}
+
+RVecF best_Z_info(RVecF pt, RVecF eta, RVecF phi, RVecF mass, const RVec<size_t>& idx){
+ 
+  RVecF out;
+  out.reserve(6);
+  size_t id1 = idx[0];
+  size_t id2 = idx[1];
+  ROOT::Math::PtEtaPhiMVector p0(pt[id1], eta[id1], phi[id1], mass[id1]);
+  ROOT::Math::PtEtaPhiMVector p1(pt[id2], eta[id2], phi[id2], mass[id2]);
+  out.emplace_back((p0+p1).pt());
+  out.emplace_back((p0+p1).eta());
+  out.emplace_back((p0+p1).phi());
+  out.emplace_back((p0+p1).mass());
+  out.emplace_back(DeltaR(eta[id1], eta[id2], phi[id1], phi[id2]));
+  out.emplace_back(DeltaPhi(phi[id1], phi[id2]));
+  return out;
+}
+
 RVecF correct_gammaIso_for_muons_and_photons(const RVec<size_t>& idx,RVecF mpt, RVecF meta, RVecF mphi,RVecF gpt, RVecF geta, RVecF gphi,RVecF giso,RVec<bool> gID) {
   RVecF result;  
   result.reserve(gpt.size());

--- a/common/pyhelpers.py
+++ b/common/pyhelpers.py
@@ -2,18 +2,20 @@ import subprocess
 import ROOT
 
 def load_meta_data(data):
+    dataframe = {}
     #Declare dataframe
-    dataframe =ROOT.RDataFrame('Events',data['files'])
+    dataframe['Events'] =ROOT.RDataFrame('Events',data['files'])
     #read the HLT string from the sample
     #dataframe=dataframe.DefinePerSample('HLTstring','rdfsampleinfo_.GetS("trigger")')
-    dataframe=dataframe.Define('HLT_passed',data['trigger']) #need to fix to suppport trigger/amples!!!!
-    dataframe=dataframe.Define('sample_isMC',str(data['isMC']))
+    dataframe['Events']=dataframe['Events'].Define('HLT_passed',data['trigger']) #need to fix to suppport trigger/amples!!!!
+    dataframe['Events']=dataframe['Events'].Define('sample_isMC',str(data['isMC']))
     #get the list of meta keys
     meta_keys =data.keys()
     for key in meta_keys:
         if key=='files' or key=='isMC' or key=='trigger':
             continue;
-        dataframe=dataframe.Define('sample_'+key,str(data[key]))
+        dataframe['Events']=dataframe['Events'].Define('sample_'+key,str(data[key]))
+    dataframe['Runs'] = ROOT.RDataFrame("Runs", data['files'])
     return dataframe
 
 


### PR DESCRIPTION
The 'Runs' tree from nanoAOD has the sum of gen weights, which we need to normalize the MC. Modified the `load_meta_data`  method to keep the run tree and added snapshots.

Other changes are to the lepton ID and minor changes to the 2g analysis to make it more similar to the selection described in the AN (still in progress)