### PR TITLE
Bug fix with ecal propagation

### DIFF
--- a/analysis/ddp_vertex.h
+++ b/analysis/ddp_vertex.h
@@ -66,6 +66,21 @@ TVector3 propToEcal(const double eta, const double phi, const int isEE, const in
     float y = sin(phi) * r;
     out.SetXYZ(x, y, ecal_z);
   }
+  else{ // Cases where both isEE an isEB==false
+    if (abs(eta) < 1.45){ // Treat as barrel
+      float r = 137;
+      float x = cos(phi) * r;
+      float y = sin(phi) * r;
+      out.SetXYZ(x, y, ecal_z);
+    }
+    else{ // Treat as endcap
+      ecal_z = 324*ecal_z/abs(ecal_z);
+      float r = ecal_z * tan(theta);
+      float dx = cos(phi) * r;
+      float dy = sin(phi) * r;
+      out.SetXYZ(dx, dy, ecal_z);
+    }
+  }
   return out;
 }
 


### PR DESCRIPTION
Some cases had both isEE and isEB set to false. These generally occur in the overlap region but had some edge cases that should be fixed with this change.