### PR TITLE
Defining veto muons for double FSR rejection

### DIFF
--- a/analysis/ddp.py
+++ b/analysis/ddp.py
@@ -14,17 +14,21 @@ def muonAna(dataframe):
     # Common Muon ID definitions (No isolation)
     muons = dataframe.Define("loose_muon", "Muon_looseId==1&&abs(Muon_eta)<2.4&&abs(Muon_dxy)<0.2&&abs(Muon_dz)<0.5&&Muon_pt>10&&Muon_pfIsoId>1")
     muons = muons.Define("tight_muon", "loose_muon&&Muon_tightId&&Muon_pfIsoId>3")
+    muons = muons.Define("veto_muon", "Muon_pt>5&&abs(Muon_eta)<2.4&&abs(Muon_dxy)<0.2&&abs(Muon_dz)<0.5&&(loose_muon==0)&&(tight_muon==0)")
     muons = muons.Define("Muon_nloose", "Sum(loose_muon)")
     muons = muons.Define("Muon_ntight", "Sum(tight_muon)")
+    muons = muons.Define("Muon_nveto", "Sum(veto_muon)")
     return muons
 
 def electronAna(dataframe):
 
     # Common Electron ID definitions
-    electrons = dataframe.Define("loose_electron", "Electron_pt>15&&abs(Electron_eta)<2.5&&(abs(Electron_eta)>1.57||abs(Electron_eta)<1.44)&&Electron_dxy<0.2&&abs(Electron_dz)<0.2&&Electron_lostHits<2&&Electron_convVeto&&Electron_cutBased>0")
+    electrons = dataframe.Define("loose_electron", "Electron_pt>15&&abs(Electron_eta)<2.5&&(abs(Electron_eta)>1.57||abs(Electron_eta)<1.44)&&abs(Electron_dxy)<0.2&&abs(Electron_dz)<0.2&&Electron_lostHits<2&&Electron_convVeto&&Electron_cutBased>0")
     electrons = electrons.Define("tight_electron", "loose_electron&&Electron_cutBased>3")
+    electrons = electrons.Define("veto_electron", "Electron_pt>55&&abs(Electron_eta)<2.5&&(abs(Electron_eta)>1.57||abs(Electron_eta)<1.44)&&abs(Electron_dxy)<0.2&&abs(Electron_dz)<0.2&&Electron_lostHits<2&&Electron_convVeto&&(tight_electron==0)&&(loose_electron==0)")
     electrons = electrons.Define("Electron_nloose", "Sum(loose_electron)")
     electrons = electrons.Define("Electron_ntight", "Sum(tight_electron)")
+    electrons = electrons.Define("Electron_nveto", "Sum(veto_electron)")
     return electrons
 
 # Must run muon + electron analyzer first to do overlap with loose leptons


### PR DESCRIPTION
Defining the number of veto muons for double FSR rejection in W->mu+nu events. Cutting on Muon_nveto>0 rejects 63% of double FSR background in MC and 3% of signal in WH samples.