### PR TITLE
Removed missing trigger from 2017B data

### DIFF
--- a/analysis/FSRsamples.py
+++ b/analysis/FSRsamples.py
@@ -23,7 +23,7 @@ samples = {
 
 # 2017 Double Muon Data
 'DoubleMuon_2017B': {'dataset': '/DoubleMuon/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD',
-                    'triggers': ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL||HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ||HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8||HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8'],
+                    'triggers': ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL||HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ||HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8'],
                     'veto_triggers': [],
                     'era': '2017',
                     'jobs': 8},


### PR DESCRIPTION
FSR analysis uses double muon trigger, one of which was not present in 2017B data. Removed this trigger from sample definition